### PR TITLE
fix: resolve internal connectivity errors when running remotely via Tailscale

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "my-app",
   "type": "module",
   "scripts": {
-    "start": "wrangler dev --persist-to .wrangler/state",
+    "start": "wrangler dev --ip 0.0.0.0 --persist-to .wrangler/state",
     "dev": "wrangler dev --persist-to .wrangler/state",
     "deploy": "wrangler deploy --minify",
     "cf-typegen": "wrangler types --env-interface CloudflareBindings",

--- a/server-client/src/acp-ws-proxy.ts
+++ b/server-client/src/acp-ws-proxy.ts
@@ -27,7 +27,7 @@ export interface ProxyHandles {
 
 const DEFAULT_PORT = 3050;
 // Bind to all interfaces so the runtime can reach the port
-const DEFAULT_HOST = "0.0.0.0";
+const DEFAULT_HOST = "127.0.0.1";
 
 // Agent type configurations
 type AgentType = "gemini" | "claude" | "codex";

--- a/server-client/src/local-agent-manager.ts
+++ b/server-client/src/local-agent-manager.ts
@@ -155,7 +155,7 @@ async function ensureAgent(agentId: string, cwd: string | null, preferredPort?: 
     agentId,
     port,
     host: PROXY_HOST,
-    httpUrl: `http://${PROXY_HOST}:${port}`,
+    httpUrl: `http://${PROXY_HOST === "0.0.0.0" ? "127.0.0.1" : PROXY_HOST}:${port}`,
     cwd,
     startedAt: new Date().toISOString(),
     proxy: startProxy({


### PR DESCRIPTION
This PR fixes the **`internal error; reference = ...`** and **`Network connection lost`** issues that occurred when attempting to access the app remotely (for example, via **Tailscale**).

---

## The Problem

When the app was configured to listen on `0.0.0.0` for remote access:

- The **Local Agent Manager** began reporting internal proxy URLs as  
  `http://0.0.0.0:PORT`
- **Cloudflare Workers (`wrangler dev`)** strictly prohibits `fetch` calls to `0.0.0.0`
- This caused:
  - Internal gateway crashes
  - Durable Object failures
  - Remote access becoming unusable

---

## The Solution

- Reverted default internal host bindings back to `127.0.0.1` for:
  - Agent Manager
  - Proxy
- Added logic in `local-agent-manager.ts` to:
  - Automatically translate `0.0.0.0` → `127.0.0.1` when reporting URLs to the Worker

---

## Result

- UI remains accessible remotely via **Tailscale / network IP**
- Internal **Worker ↔ Proxy** communication stays stable on the loopback address
- No more Cloudflare Worker crashes 