### PR TITLE
Add optional HTTP Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ Use a strong password. This exposes your machine to the internet.
 
 ## Optional Configuration
 
-Sled reads runtime options from environment variables (e.g. `.dev.vars` or `wrangler.jsonc`).
+Sled reads runtime options from environment variables (e.g. `app/.dev.vars` for `wrangler dev`, or `wrangler.jsonc` for production).
+
+- `BASIC_AUTH_USER` + `BASIC_AUTH_PASS` (optional): Enable app-level HTTP Basic Auth. If either is unset, auth is disabled. For local dev, put them in `app/.dev.vars`. For production, use `wrangler secret put` or your deploy env.
 
 - `DISABLE_VOICE_MODE` (optional): Set to any non-empty value other than `false` to disable voice mode and all connections to layercode.com's voice API. Leave unset/empty/`false` to keep voice mode enabled.
 

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -1,6 +1,7 @@
 // Main entry point - Hono app with routes
 
 import { Hono } from "hono";
+import { basicAuth } from "hono/basic-auth";
 import { jsxRenderer } from "hono/jsx-renderer";
 
 // Re-export the Durable Object for Cloudflare Workers
@@ -59,6 +60,15 @@ async function fetchRunningAgentIds(env: Bindings, agentIds: string[]): Promise<
 }
 
 const app = new Hono<{ Bindings: Bindings }>();
+
+app.use("*", async (c, next) => {
+  const authUser = c.env.BASIC_AUTH_USER?.trim();
+  const authPass = c.env.BASIC_AUTH_PASS?.trim();
+  if (!authUser || !authPass) {
+    return next();
+  }
+  return basicAuth({ username: authUser, password: authPass })(c, next);
+});
 
 // Subdomain routing: AGENTID.layercode.ai or AGENTID.localhost (reserved for future app proxy)
 app.use("*", async (c, next) => {

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -87,6 +87,8 @@ export type Bindings = {
   SLED_AGENT: DurableObjectNamespace<import("./durableObject").SledAgent>;
   LOCAL_AGENT_MANAGER_URL?: string;
   DEBUG_LOG?: string;
+  BASIC_AUTH_USER?: string;
+  BASIC_AUTH_PASS?: string;
   DB: D1Database;
   // Google AI API key (for generating conversation titles)
   GOOGLE_AI_API_KEY?: string;


### PR DESCRIPTION
## Summary

- Add app-level HTTP Basic Auth middleware driven by env vars.
- Document BASIC_AUTH_USER/PASS usage for local dev and production.